### PR TITLE
Windows with borders and prop for scrollable content

### DIFF
--- a/example/src/sample4.vue
+++ b/example/src/sample4.vue
@@ -16,19 +16,17 @@
             </div>
         </hsc-window>
 
-        <hsc-window title="Scrollable" :resizable="true" :minWidth="100" :minHeight="100" :maxWidth="200" :maxHeight="200">
-            <div style="height: 100%; overflow: auto;">
-                <table>
-                    <tr>
-                        <th>&times;</th>
-                        <th v-for="j in range(n)" :key="j" v-html="j"></th>
-                    </tr>
-                    <tr v-for="i in range(n)" :key="i">
-                        <th v-html="i" />
-                        <td v-for="j in range(n)" :key="j" v-html="hex(i/n * j/n)" :style="{ backgroundColor: `rgb(${Math.floor(255 * i / n)}, ${Math.floor(255 * j / n)}, 127)` }" />
-                    </tr>
-                </table>
-            </div>
+        <hsc-window title="Scrollable" :resizable="true" :isScrollable="true" :minWidth="100" :minHeight="100" :maxWidth="200" :maxHeight="200">
+            <table>
+                <tr>
+                    <th>&times;</th>
+                    <th v-for="j in range(n)" :key="j" v-html="j"></th>
+                </tr>
+                <tr v-for="i in range(n)" :key="i">
+                    <th v-html="i" />
+                    <td v-for="j in range(n)" :key="j" v-html="hex(i/n * j/n)" :style="{ backgroundColor: `rgb(${Math.floor(255 * i / n)}, ${Math.floor(255 * j / n)}, 127)` }" />
+                </tr>
+            </table>
         </hsc-window>
 
         Gradation samples from

--- a/example/src/sample7.vue
+++ b/example/src/sample7.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <component v-for="(style, name) in styles" :is="style" :key="name">
-            <hsc-window :title="name" :closeButton="true" :isOpen="isOpen[name]" @closebuttonclick="isOpen[name] = false">
+            <hsc-window :resizable="true" :initialWidth="200" :initialHeight="200" :title="name" :closeButton="true" :isOpen="isOpen[name]" @closebuttonclick="isOpen[name] = false">
                 Parameters:
                 <fieldset>
                     <legend>&alpha;</legend>
@@ -40,6 +40,7 @@ const StyleBluegreen = StyleFactory({
         background: 'linear-gradient(to bottom, rgba(0, 0, 0, 0.25), #436f7c)'
     },
     window: {
+        border: '1px solid #f00',
         color: 'white',
         boxShadow: '0 2pt 8pt rgba(0, 0, 0, 0.5)'
     },

--- a/src/window/index.vue
+++ b/src/window/index.vue
@@ -27,6 +27,7 @@ export default WindowType
 <style lang="scss" scoped>
 .window {
     display: flex;
+    overflow: hidden;
     flex-flow: column;
     position: absolute;
     border-radius: 4pt 4pt 0 0;

--- a/src/window/script.ts
+++ b/src/window/script.ts
@@ -26,6 +26,9 @@ export class WindowType extends Vue {
     @Prop({ type: Boolean, default: false })
     resizable: boolean
 
+    @Prop({ type: Boolean, default: false })
+    isScrollable: boolean
+
     @Prop({ type: Boolean, default: true })
     activateWhenOpen: boolean
 
@@ -88,9 +91,17 @@ export class WindowType extends Vue {
     }
 
     get styleContent() {
-        return this.resizable ?
-            { ...this.windowStyle.content, padding: '0' }
-            : this.windowStyle.content
+        let style = this.windowStyle.content;
+
+        if (this.resizable) {
+            style.padding = '0';
+        }
+
+        if (this.isScrollable) {
+            style.overflow = 'auto';
+        }
+
+        return style;
     }
 
     @Watch('resizable')

--- a/src/window/script.ts
+++ b/src/window/script.ts
@@ -129,9 +129,9 @@ export class WindowType extends Vue {
     initialHeight?: number
 
     private setDimension() {
-        const content = this.contentElement()
-        if (this.initialWidth != undefined) content.style.width = `${this.initialWidth}px`
-        if (this.initialHeight != undefined) content.style.height = `${this.initialHeight}px`
+        const winEl = this.windowElement()
+        if (this.initialWidth != undefined) winEl.style.width = `${this.initialWidth}px`
+        if (this.initialHeight != undefined) winEl.style.height = `${this.initialHeight}px`
     }
 
     @Prop({ type: Number, default: 0 })
@@ -149,20 +149,11 @@ export class WindowType extends Vue {
     private initResizeHelper() {
         const { height: titlebarHeight } = naturalSize(this.titlebarElement())
         this.resizableHelper = new ResizableHelper(this.windowElement(), {
-            onResize: () => this.onResize(),
             minWidth: this.minWidth,
             minHeight: this.minHeight + titlebarHeight,
             maxWidth: this.maxWidth,
             maxHeight: this.maxHeight ? this.maxHeight + titlebarHeight : undefined,
         })
-    }
-
-    private onResize() {
-        const { width: wWidth, height: wHeight } = this.windowElement().getBoundingClientRect()
-        const { height: tHeight } = this.titlebarElement().getBoundingClientRect()
-        const content = this.contentElement()
-        content.style.width = `${wWidth}px`
-        content.style.height = `${wHeight - tHeight}px`
     }
 }
 


### PR DESCRIPTION
Found it hard to style resizable windows with borders, the content was overflowing the window border. The fix for this problem makes the "scrollable" window in sample 4 not work. So to fix this issue I added a new window property "isScrollable".